### PR TITLE
Adiciona botão "repete aluguel"

### DIFF
--- a/inn/urls.py
+++ b/inn/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     path('aluguel/novo', aluguel.aluguel_novo),
     path('aluguel/<int:idt>', aluguel.aluguel_por_id, name='editar_aluguel'),
     path('aluguel/edita/<int:idt>', aluguel.aluguel_edita),
+    path('aluguel/repete/<int:idt>', aluguel.aluguel_repete_por_id, name='repetir_aluguel'),
     path('reforma/lista', reforma.reforma_todos),
     path('reforma/lista/ano/<int:year>', reforma.reforma_todos_por_ano),
     path('reforma/novo', reforma.reforma_novo),

--- a/innapp/tables.py
+++ b/innapp/tables.py
@@ -38,7 +38,8 @@ class AluguelTable(Table):
     dt_criacao = DatetimeColumn(header='dt. criação', field='dt_criacao', format='%d/%m/%Y %H:%M', header_attrs={'style': 'text-align:center;'})
     dt_atualizacao = DatetimeColumn(header='dt. atualização', field='dt_atualizacao', format='%d/%m/%Y %H:%M', header_attrs={'style': 'text-align:center;'})
     acoes = LinkColumn(header='ações', sortable=False, links=[
-        Link(text='', viewname='editar_aluguel', args=[A('pk')], attrs={'class': 'fa fa-pencil-square-o fa-fw'})
+        Link(text='', viewname='editar_aluguel', args=[A('pk')], attrs={'class': 'fa fa-pencil-square-o fa-fw'}),
+        Link(text='', viewname='repetir_aluguel', args=[A('pk')], attrs={'class': 'fa fa-clone fa-fw'})
     ], header_attrs={'style': 'text-align:center;'})
 
 

--- a/innapp/views/aluguel.py
+++ b/innapp/views/aluguel.py
@@ -113,6 +113,41 @@ def aluguel_edita(request, idt):
     return render(request, 'innapp/aluguel.html', {'template': aluguel_map})
 
 
+@login_required(login_url='/acesso/login')
+def aluguel_repete_por_id(request, idt):
+    aluguel_map = {}
+
+    if not idt:
+        aluguel_map['message'] = 'Registro inválido'
+        aluguel_map['status'] = 'danger'
+        return render(request, 'innapp/aluguel.html', {'template': aluguel_map})
+
+    try:
+        aluguel = AluguelTbl.objects.get(idt_aluguel=idt)
+
+        hoje = datetime.date.today()
+
+        dt_recebimento = ajusta_para_apresentacao(hoje)
+
+        aluguel_map = aluguel_template(ano=hoje.year)
+
+        aluguel_form = AluguelForm(initial={
+            'idt_imovel': aluguel.idt_imovel,
+            'idt_inquilino': aluguel.idt_inquilino,
+            'dt_recebimento': dt_recebimento,
+            'num_aluguel': aluguel.num_aluguel,
+            'mes_referencia': hoje.month,
+            'num_administracao': aluguel.num_administracao,
+            'num_acordo': aluguel.num_acordo,
+        })
+        aluguel_map['form'] = aluguel_form
+    except AluguelTbl.DoesNotExist:
+        aluguel_map['message'] = 'Registro não encontrado'
+        aluguel_map['status'] = 'danger'
+
+    return render(request, 'innapp/aluguel.html', {'template': aluguel_dependencias(aluguel_map)})
+
+
 def aluguel_template(idt_reg=0, ano=None):
     if ano is None:
         ano = datetime.date.today().year


### PR DESCRIPTION
 - Objetivo é realizar a cópia de dados de um aluguel selecionado para dessa forma popular o formulário com informações para "data recebimento" e "mês referência" com os dados de data do momento da ação, demais campos são mantidos e ficam disponíveis para alteração, caso necessário.